### PR TITLE
Compatibility with v1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.0'
           - '1.2'
           - '1'
           - 'nightly'

--- a/src/PkgVersion.jl
+++ b/src/PkgVersion.jl
@@ -22,7 +22,8 @@ function project_data(pf::AbstractString, name, T::Union{Type,Function}, default
         res = getfield(pr, Symbol(name))
         res === nothing ? T(default) : res
     else
-        res = get(() -> T(default), pr.other, string(name))
+        d = pr isa Dict ? pr : pr.other
+        res = get(() -> T(default), d, string(name))
         res isa AbstractVector ? res[1] : res
     end
 end


### PR DESCRIPTION
I see that the tests passed on Julia v1.0 here before. But when I try to build this package with that version, it crashes with the message that `pr` is a `Dict` with no field `other`.