### PR TITLE
Remove dependency on Pkg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,7 @@
 name = "PkgVersion"
 uuid = "eebad327-c553-4316-9ea0-9fa01ccd7688"
 authors = ["KlausC <klausC@users.noreply.github.com> and contributors"]
-version = "0.3.3"
-
-[deps]
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "0.4.0"
 
 [compat]
 julia = "1"

--- a/src/PkgVersion.jl
+++ b/src/PkgVersion.jl
@@ -1,5 +1,13 @@
 module PkgVersion
-using Pkg
+
+# Copied from Pkg/src/Types.jl:186
+function projectfile_path(env_path::String; strict=false)
+    for name in Base.project_names
+        maybe_file = joinpath(env_path, name)
+        isfile(maybe_file) && return maybe_file
+    end
+    return strict ? nothing : joinpath(env_path, "Project.toml")
+end
 
 function project_data(m::Module, name, T, default)
     function _pkgdir(m::Module)
@@ -12,7 +20,7 @@ function project_data(m::Module, name, T, default)
     end
     pf = _pkgdir(m)
     pf === nothing && return T(default)
-    pf = Pkg.Types.projectfile_path(pf)
+    pf = projectfile_path(pf)
     project_data(pf, name, T, default)
 end
 


### PR DESCRIPTION
In Julia v1.11, `Pkg` is no longer part of the system image, and will introduce quite a bit of loading latency when the package is first loaded.  

This PR removes the dependency on Pkg (it looks like only one Pkg function was used here).

